### PR TITLE
Modify regex to detect specific flake8 errors.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -44,7 +44,7 @@ class Flake8(PythonLinter):
 
     regex = (
         r'^.+?:(?P<line>\d+):(?P<col>\d+): '
-        r'(?:(?P<error>[FEWCN](?:40[24]|812|8(2[1-3]|31)|11[23]|90[12]))|'
+        r'(?:(?P<error>(?:F(?:40[24]|8(?:12|2[123]|31))|E(?:11[23]|90[12])))|'
         r'(?P<warning>[FEWCN]\d+)) '
         r'(?P<message>(?P<near>\'.+\') imported but unused|.*)'
     )


### PR DESCRIPTION
This change causes SublimeLinter to color code errors differently than warnings.  

This list of errors is highly subjective, but I believe the following pep8/pyflakes reports are errors, while everything else is a warning.

Pyflake Errors:
- F402    import module from line N shadowed by loop variable
- F404    future import(s) name after other statements
- F812    list comprehension redefines name from line N
- F823    local variable name ... referenced before assignment
- F831    duplicate argument name in function definition
- F821    undefined name name
- F822    undefined name name in `__all__`

Pep8 Errors:
- E112    expected an indented block
- E113    unexpected indentation
- E901    SyntaxError or IndentationError
- E902    IOError

I also want to note that I'm not very familiar with F822, "undefined name name in `__all__`".  When I've encountered it, it has usually been a false-positive.  This is probably a bug and not an intended design on pyflakes part, so I'm leaving it as an error even though in most real-world situations it will probably act as a warning.  It's because of issues like this that I feel my categorization of error vs warning is highly subjective.
