### PR TITLE
Option to show flake8 code in message

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -55,7 +55,8 @@ class Flake8(PythonLinter):
         '--builtins=,': '',
         '--max-line-length=': None,
         '--max-complexity=': -1,
-        '--jobs=': '1'
+        '--jobs=': '1',
+        '--show-code=': False,
     }
     inline_settings = ('max-line-length', 'max-complexity')
     inline_overrides = ('select', 'ignore', 'builtins')
@@ -64,6 +65,7 @@ class Flake8(PythonLinter):
 
     # Internal
     report = None
+    show_code = False
     pyflakes_checker_module = None
     pyflakes_checker_class = None
 
@@ -110,10 +112,12 @@ class Flake8(PythonLinter):
             'ignore': [],
             'builtins': '',
             'max-line-length': 0,
-            'max-complexity': 0
+            'max-complexity': 0,
+            'show-code': False,
         }
 
         self.build_options(options, type_map, transform=lambda s: s.replace('-', '_'))
+        self.show_code = options.pop('show_code', False)
 
         if persist.debug_mode():
             persist.printf('{} options: {}'.format(self.name, options))
@@ -144,6 +148,8 @@ class Flake8(PythonLinter):
         if near:
             col = None
 
+        if self.show_code:
+            message = ' '.join([error or warning or '', message])
         return match, line, col, error, warning, message, near
 
     def get_report(self):


### PR DESCRIPTION
Fix to #14.

A new option `show-code` is added to toggle the behaviour (disabled by default). If the option is on, the error/warning code from flake8 will be prepend back to the message.

How it looks:

![Error message with code in statue bar](https://cloud.githubusercontent.com/assets/605277/7292143/a4964e26-e9cb-11e4-8ada-da1076fb9b6c.png)

![Error message with code in panel](https://cloud.githubusercontent.com/assets/605277/7292146/a9fc0dba-e9cb-11e4-9334-4ba9f1dfb94c.png)