### PR TITLE
Show all other flake8 warnings

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -45,7 +45,7 @@ class Flake8(PythonLinter):
     regex = (
         r'^.+?:(?P<line>\d+):(?P<col>\d+): '
         r'(?:(?P<error>(?:F(?:40[24]|8(?:12|2[123]|31))|E(?:11[23]|90[12])))|'
-        r'(?P<warning>[FEWCN]\d+)) '
+        r'(?P<warning>\w\d+)) '
         r'(?P<message>(?P<near>\'.+\') imported but unused|.*)'
     )
     multiline = True


### PR DESCRIPTION
The plugin currently ignores all other flake8 warnings if they don't start with one of the known error letters (FEWCN).

This should allow all other messages to be shown as warnings.

Fixes #11.