### PR TITLE
Make the linter understand that Python3 files should be linted too

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,7 @@ from SublimeLinter.lint import PythonLinter
 class Flake8(PythonLinter):
     """Provides an interface to the flake8 python module/script."""
 
-    syntax = 'python'
+    syntax = ('python', 'python3')
     cmd = ('flake8', '*', '-')
     version_args = '--version'
     version_re = r'^(?P<version>\d+\.\d+\.\d+)'


### PR DESCRIPTION
There is a Python3 plugin for Sublime which provides new syntax definitions for python 3. This change will allow flake8 to lint python files highlighted with the "Python3" syntax.