### PR TITLE
Better parsing for "'%s' imported but unused".

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -45,7 +45,7 @@ class Flake8(PythonLinter):
         r'^.+?:(?P<line>\d+):(?P<col>\d+): '
         r'(?:(?P<error>(?:F(?:40[24]|8(?:12|2[123]|31))|E(?:11[23]|90[12])))|'
         r'(?P<warning>\w\d+)) '
-        r'(?P<message>(?P<near>\'.+\') imported but unused|.*)'
+        r'(?P<message>\'(.*\.)?(?P<near>.+)\' imported but unused|.*)'
     )
     multiline = True
     defaults = {


### PR DESCRIPTION
This new regex tries to parse the actual name of the module being
imported, instead of passing the entire message. It only extracts the
module name, discarding the rest of the package hierarchy (which is
useless for finding what to underline in ST anyway).

e.g.
```python
from package.nestedpackage.modulex import y
```

> 'package.nestedpackage.modulex.y' imported but unused

`near='y'`

Before:
![image](https://cloud.githubusercontent.com/assets/163961/19083021/cad4c63a-8a60-11e6-93b5-025090077425.png)

After:
![image](https://cloud.githubusercontent.com/assets/163961/19083046/e18e6aca-8a60-11e6-82b8-1cc0de40054d.png)
