### PR TITLE
Allow python linter to run with specified @python

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,10 +18,11 @@ class Flake8(PythonLinter):
     """Provides an interface to the flake8 python module/script."""
 
     syntax = ('python', 'python3')
-    cmd = ('flake8', '*', '-')
+    cmd = ('flake8@python', '*', '-')
     version_args = '--version'
     version_re = r'^(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 2.2.2'
+    check_version = True
 
     # The following regex marks these pyflakes and pep8 codes as errors.
     # All other codes are marked as warnings.


### PR DESCRIPTION
- followed the SublimeLinter official docs:
  http://www.sublimelinter.com/en/latest/python_linter.html#pythonlinter-class
  
  with some help of the code:
  https://github.com/SublimeLinter/SublimeLinter3/blob/2cab34326b9b8bfe994e1b6d5faa30a6274eb804/lint/python_linter.py#L195

should resolve at least issue #43 

_Note_: This requires the specified python versions to be found on the path. Modifying the path in SublimeLinter settings works well for this purpose; however, the linter uses the first flake8 entry script version found, e.g this is possible:

```
/Users/pavel/.pyenv/versions/3.5.2/bin/python /Users/pavel/.pyenv/versions/2.7.11/bin/flake8 --version
3.0.4 (mccabe: 0.5.2, pycodestyle: 2.0.0, pyflakes: 1.2.3) CPython 3.5.2 on Darwin
```
