### PR TITLE
Allow different python versions and enable virtualenv.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,10 +18,11 @@ class Flake8(PythonLinter):
     """Provides an interface to the flake8 python module/script."""
 
     syntax = ('python', 'python3')
-    cmd = ('flake8', '*', '-')
+    cmd = ('flake8@python', '*', '-')
     version_args = '--version'
     version_re = r'^(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 2.2.2'
+    check_version = True
 
     # The following regex marks these pyflakes and pep8 codes as errors.
     # All other codes are marked as warnings.


### PR DESCRIPTION
Unless cmd is defined with `@python`, SublimeLinter will always use ST's
python, which is version 3. By using `@python` we can choose the version
on a per-project basis.

Pull request #41 has removed this, which IMO was a mistake.

Also, without `check_version = True`, SublimeLinter will not honor the
python version defined in the settings (e.g. .sublimelinterrc), and will
always default to the system version. This is crucial for usage in
projects with a defined virtualenv, where the "@python" setting is set
to the virutalenv's binary.