### PR TITLE
Complete Rewrite

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -11,18 +11,149 @@
 
 """This module exports the Flake8 plugin linter class."""
 
-from SublimeLinter.lint import PythonLinter
+from functools import lru_cache
+
+from SublimeLinter.lint import Linter, persist
+from . import util
+
+
+class PythonLinter(Linter):
+    @classmethod
+    @lru_cache(maxsize=None)
+    def can_lint(cls, syntax):
+        """Determine optimistically if the linter can handle the provided syntax."""
+        can = False
+        syntax = syntax.lower()
+
+        if cls.syntax:
+            if isinstance(cls.syntax, (tuple, list)):
+                can = syntax in cls.syntax
+            elif cls.syntax == '*':
+                can = True
+            elif isinstance(cls.syntax, str):
+                can = syntax == cls.syntax
+            else:
+                can = cls.syntax.match(syntax) is not None
+
+        return can
+
+    def context_sensitive_executable_path(self, cmd):
+        """Try to find an executable for a given cmd"""
+
+        settings = self.get_view_settings()
+
+        # If the user explicitly set an executable, it takes precedence.
+        # We expand environment variables. E.g. a user could have a project
+        # structure where a virtual environment is always located within
+        # the project structure. She could then simply specify
+        # `${project_path}/venv/bin/flake8`. Note that setting `@python`
+        # to a path will have a similar effect.
+        executable = settings.get('executable', '')
+        if executable:
+            executable = util.expand_variables(executable)
+
+            persist.printf(
+                "{}: wanted executable is '{}'".format(self.name, executable)
+            )
+
+            if util.can_exec(executable):
+                return True, executable
+
+            persist.printf(
+                "ERROR: {} deactivated, cannot locate '{}' "
+                .format(self.name, executable)
+            )
+            # no fallback, the user specified something, so we err
+            return True, None
+
+        # `@python` can be number or a string. If it is a string it should
+        # point to a python environment, NOT a python binary.
+        # We expand environment variables. E.g. a user could have a project
+        # structure where virtual envs are located always like such
+        # `some/where/venvs/${project_base_name}` or she has the venv
+        # contained in the project dir `${project_path}/venv`. She then
+        # could edit the global settings once and can be sure that always the
+        # right linter installed in the virtual environment gets executed.
+        python = settings.get('@python', None)
+        if isinstance(python, str):
+            python = util.expand_variables(python)
+
+        persist.printf(
+            "{}: wanted @python is '{}'".format(self.name, python)
+        )
+
+        cmd_name = cmd[0] if isinstance(cmd, (list, tuple)) else cmd
+
+        if python:
+            if isinstance(python, str):
+                executable = util.find_script_by_python_env(
+                    python, cmd_name
+                )
+                if not executable:
+                    persist.printf(
+                        "WARNING: {} deactivated, cannot locate '{}' "
+                        "for given @python '{}'"
+                        .format(self.name, cmd_name, python)
+                    )
+                    # Do not fallback, user specified something we didn't find
+                    return True, None
+
+                return True, executable
+
+            else:
+                executable = util.find_script_by_python_version(
+                    cmd_name, str(python)
+                )
+
+                # If we didn't find anything useful, use the legacy
+                # code from SublimeLinter for resolving that version.
+                if executable is None:
+                    persist.printf(
+                        "{}: Still trying to resolve {}, now trying "
+                        "SublimeLinter's legacy code."
+                        .format(self.name, python)
+                    )
+                    _, executable, *_ = util.find_python(
+                        str(python), cmd_name
+                    )
+
+                if executable is None:
+                    persist.printf(
+                        "WARNING: {} deactivated, cannot locate '{}' "
+                        "for given @python '{}'"
+                        .format(self.name, cmd_name, python)
+                    )
+                    return True, None
+
+                persist.printf(
+                    "{}: Using {} for given @python '{}'"
+                    .format(self.name, executable, python)
+                )
+                return True, executable
+
+        # If we're here the user didn't specify anything. We do a simple
+        # `which` now. But I think we could do better. Maybe a `pyenv which`
+        # or `pipenv which`
+        persist.printf(
+            "{}: trying to use globally installed {}"
+            .format(self.name, cmd_name)
+        )
+        # fallback, similiar to a which(cmd)
+        executable = util.find_executable(cmd_name)
+        if executable is None:
+            persist.printf(
+                "WARNING: cannot locate '{}'. Fill in the '@python' or "
+                "'executable' setting."
+                .format(self.name)
+            )
+        return True, executable
 
 
 class Flake8(PythonLinter):
     """Provides an interface to the flake8 python module/script."""
 
     syntax = ('python', 'python3')
-    cmd = ('flake8@python', '*', '-')
-    version_args = '--version'
-    version_re = r'^(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 2.2.2'
-    check_version = True
+    cmd = ('flake8', '*', '-')  # do not specify `@python` bc we do our own
 
     # The following regex marks these pyflakes and pep8 codes as errors.
     # All other codes are marked as warnings.
@@ -87,14 +218,3 @@ class Flake8(PythonLinter):
         if self.get_view_settings().get('show-code'):
             message = ' '.join([error or warning or '', message])
         return match, line, col, error, warning, message, near
-
-    def build_cmd(self, cmd=None):
-        """Return a tuple with the command line to execute."""
-
-        executable = self.get_view_settings().get('executable', None)
-        if executable:
-            args = (cmd or self.cmd)[1:]
-            cmd = (executable, ) + args
-            return self.insert_args(cmd)
-        else:
-            return super().build_cmd(cmd)

--- a/util.py
+++ b/util.py
@@ -1,0 +1,93 @@
+from functools import lru_cache
+import os
+
+import sublime
+from SublimeLinter.lint import util, persist
+
+
+def _find_executables(executable):
+    env = util.create_environment()
+
+    for base in env.get('PATH', '').split(os.pathsep):
+        path = os.path.join(os.path.expanduser(base), executable)
+
+        # On Windows, if path does not have an extension, try .exe, .cmd, .bat
+        if sublime.platform() == 'windows' and not os.path.splitext(path)[1]:
+            for extension in ('.exe', '.cmd', '.bat'):
+                path_ext = path + extension
+
+                if util.can_exec(path_ext):
+                    yield path_ext
+        elif util.can_exec(path):
+            yield path
+
+    return None
+
+
+@lru_cache(maxsize=None)
+def find_executable(executable):
+    for path in _find_executables(executable):
+        return path
+
+    return None
+
+
+def find_python_version(version):  # type: Str
+    requested_version = util.extract_major_minor_version(version)
+    for python in _find_executables('python'):
+        python_version = util.get_python_version(python)
+        if util.version_fulfills_request(python_version, requested_version):
+            yield python
+
+    return None
+
+
+@lru_cache(maxsize=None)
+def find_script_by_python_version(script_name, version):
+    """
+    Given a version string for python and a script name, try to return a
+    full path to such a script if any.
+    """
+
+    # They can be multiple matching pythons. We try to find a python with
+    # its complete environment, not just a symbolic link or so.
+    for python in find_python_version(version):
+        python_env = os.path.dirname(python)
+        script_path = find_script_by_python_env(python_env, script_name)
+        if script_path:
+            return script_path
+
+    return None
+
+
+@lru_cache(maxsize=None)
+def find_script_by_python_env(python_env_path, script):
+    """
+    Return full path to a script installed in a python environment.
+
+    `python_env_path` is the base path of a python installation or virtual
+    environment.
+    """
+    posix = sublime.platform() in ('osx', 'linux')
+
+    if posix:
+        full_path = os.path.join(python_env_path, 'bin', script)
+    else:
+        full_path = os.path.join(python_env_path, 'Scripts', script + '.exe')
+
+    persist.printf("trying {}".format(full_path))
+    if os.path.exists(full_path):
+        return full_path
+
+    return None
+
+
+def expand_variables(string):
+    window = sublime.active_window()
+    env = window.extract_variables()
+    return sublime.expand_variables(string, env)
+
+
+# re-export for convenience
+find_python = util.find_python
+can_exec = util.can_exec


### PR DESCRIPTION
Current version after #51 breaks for people. This is disappointing esp. for users which can run flake8 on the command line just perfectly bc it's globally installed and still see the plugin failing. They mostly have pretty standard installs as well. Some people had to revert #51 manually event though @asfaltboy tried its best to help. See #56 for details. 

My own #41 broke other people. Mostly because it disabled the `@python` setting completely and it wasn't documented at all that a new setting `executable` was introduced which basically could handle everything without any magic. 

So this is a new attempt. 

The code implements  a new `PythonLinter` class in two methods. The actual `Flake8` linter then becomes pure configuration. It is intended that the new `PythonLinter` could be as well used by other python linters; maybe it could be merged into SublimeLinter. The strategy is of course to try this here locally first.

--- Features

 - If you just install the plugin, the linter will basically do a `which(flake8)` t.i. it will choose the globally installed `flake8`. This is the least surprising behavior and probably the 90% use-case. 
 - If you specify `@python` and set a number: It will try to find a good python, searching your paths, and then search for a flake8 that belongs to that installation. (I've fixed some bugs here. So this is the same feature as before, but works more reliable.)
 - If you specify `@python` and set it to a path it will take that environment, which is probably a virtual env, and assumes flake8 is installed there. So basically it looks for `<path>/bin/flake8` resp. `<path>/Scripts/flake8.exe`. 
 - If everything fails, you can set `executable` to a flake8 bin. So you always have that as a fallback.

All paths be it in `@python` or `executable` will get the sublime env variables expanded. E.g. you could set `@python` to `${project_path}/venv` etc.

