### PR TITLE
Remove default settings

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -54,9 +54,9 @@ class Flake8(PythonLinter):
         '--select=,': '',
         '--ignore=,': '',
         '--builtins=,': '',
-        '--max-line-length=': None,
-        '--max-complexity=': -1,
-        '--jobs=': '1',
+        '--max-line-length=': '',
+        '--max-complexity=': '',
+        '--jobs=': '',
         'show-code': False,
         'executable': ''
     }


### PR DESCRIPTION
Fixes https://github.com/SublimeLinter/SublimeLinter-flake8/issues/58

Since all defaults we set here land on the command line, they mask possible settings in config files like `.flake8`. This is a bad **default** behavior.