### PR TITLE
adds `--config` option to inline overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ In addition to the standard SublimeLinter settings, SublimeLinter-flake8 provide
 |max-line-length|The maximum allowed line length. `null` uses the PEP8 default of 79.|&#10003;| |
 |max-complexity|The maximum allowed code complexity. -1 allows unlimited complexity.|&#10003;| |
 |show-code|Displays the flake8 error code in the message, `False` by default.|&#10003;| |
+|config|Absolute path to any ini-style config file. `None` by default uses settings.| |&#10003;|
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:

--- a/linter.py
+++ b/linter.py
@@ -204,11 +204,12 @@ class Flake8(PythonLinter):
         '--max-line-length=': '',
         '--max-complexity=': '',
         '--jobs=': '',
+        '--config=': None,
         'show-code': False,
         'executable': ''
     }
     inline_settings = ('max-line-length', 'max-complexity')
-    inline_overrides = ('select', 'ignore', 'builtins')
+    inline_overrides = ('select', 'ignore', 'builtins', 'config')
 
     # ST will not show error marks in whitespace errors, so bump the column by one
     # e.g. `E203 whitespace before ':'`


### PR DESCRIPTION
This allows a user to supply an absolute path to an ini-formatted config
file that isn't one of the standard `.flake8`, `setup.cfg` or `tox.ini`

usage in project settings:
```json
{
	"SublimeLinter": {
		"linters": {
			"flake8": {
				"config": "/path/to/some/config.ini"
			}
		}
	}
}
```

i'm not sure if this is generally useful, but my case, my main work project keeps its config in a nonstandard path so i'm using this forked version to get linting working but if there's a better approach, i'm all game.