### PR TITLE
Fix inline settings

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -23,6 +23,8 @@ class PythonLinter(Linter):
     Supposed to work for other python linters as well. But not yet.
     """
 
+    comment_re = r'\s*#'
+
     @classmethod
     @lru_cache(maxsize=None)
     def can_lint(cls, syntax):


### PR DESCRIPTION
Without a `comment_re` setting, inline settings don't work.

This is a regression, and even if we don't ship this in SL4, it is okay to have it in SL3. 😉 

Fixes: https://github.com/SublimeLinter/SublimeLinter3/issues/679