### PR TITLE
clean up several features now handled in core:

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -47,6 +47,3 @@ class Flake8(PythonLinter):
         r'(?P<message>\'(.*\.)?(?P<near>.+)\' imported but unused|.*)'
     )
     multiline = True
-    defaults = {
-       'executable': ''
-    }

--- a/linter.py
+++ b/linter.py
@@ -56,5 +56,3 @@ class Flake8(PythonLinter):
         '--jobs=': '',
         'executable': ''
     }
-    inline_settings = ('max-line-length', 'max-complexity')
-    inline_overrides = ('select', 'ignore', 'builtins')

--- a/linter.py
+++ b/linter.py
@@ -54,32 +54,7 @@ class Flake8(PythonLinter):
         '--max-line-length=': '',
         '--max-complexity=': '',
         '--jobs=': '',
-        'show-code': False,
         'executable': ''
     }
     inline_settings = ('max-line-length', 'max-complexity')
     inline_overrides = ('select', 'ignore', 'builtins')
-
-    # ST will not show error marks in whitespace errors, so bump the column by one
-    # e.g. `E203 whitespace before ':'`
-    increment_col = ('E203',)
-
-    def split_match(self, match):
-        """
-        Extract and return values from match.
-
-        We override this method because sometimes we capture near,
-        and a column will always override near.
-
-        """
-        match, line, col, error, warning, message, near = super().split_match(match)
-
-        if near:
-            col = None
-
-        if col and any(c in self.increment_col for c in (error, warning)):
-            col += 1
-
-        if self.get_view_settings().get('show-code'):
-            message = ' '.join([error or warning or '', message])
-        return match, line, col, error, warning, message, near

--- a/linter.py
+++ b/linter.py
@@ -48,11 +48,5 @@ class Flake8(PythonLinter):
     )
     multiline = True
     defaults = {
-        '--select=,': '',
-        '--ignore=,': '',
-        '--builtins=,': '',
-        '--max-line-length=': '',
-        '--max-complexity=': '',
-        '--jobs=': '',
-        'executable': ''
+       'executable': ''
     }

--- a/linter.py
+++ b/linter.py
@@ -19,7 +19,7 @@ class Flake8(PythonLinter):
     """Provides an interface to the flake8 python module/script."""
 
     syntax = ('python', 'python3')
-    cmd = ('flake8', '--format', 'default', '*', '-')
+    cmd = ('flake8', '--format', 'default', '${args}', '-')
 
     # The following regex marks these pyflakes and pep8 codes as errors.
     # All other codes are marked as warnings.


### PR DESCRIPTION
- error codes are already displayed if captured
- whitespace errors are now always highlighted
- no more need to override split_match