### PR TITLE
Filter WS errors Sublime can auto-fix

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -46,12 +46,12 @@ class Flake8(PythonLinter):
         and a column will always override near.
 
         """
-        match, line, col, error, warning, message, near = super().split_match(match)
+        match = super().split_match(match)
 
-        if near:
-            col = None
+        if match.near:
+            return match._replace(col=None)
 
-        return match, line, col, error, warning, message, near
+        return match
 
     def reposition_match(self, line, col, m, virtual_view):
         """Reposition white-space errors."""

--- a/linter.py
+++ b/linter.py
@@ -8,7 +8,9 @@ class Flake8(PythonLinter):
 
     cmd = ('flake8', '--format', 'default', '${args}', '-')
     defaults = {
-        'selector': 'source.python'
+        'selector': 'source.python',
+        # By default, filter codes Sublime can auto-fix
+        'filter-codes': ['W291', 'W293', 'W391']
     }
 
     # The following regex marks these pyflakes and pep8 codes as errors.
@@ -37,6 +39,16 @@ class Flake8(PythonLinter):
         r'(?P<message>\'(.*\.)?(?P<near>.+)\' imported but unused|.*)'
     )
     multiline = True
+
+    def parse_output(self, proc, virtual_view):
+        settings = self.get_view_settings()
+        filter_codes = settings.get('filter-codes', [])
+
+        return [
+            error
+            for error in super().parse_output(proc, virtual_view)
+            if error['code'] not in filter_codes
+        ]
 
     def split_match(self, match):
         """

--- a/linter.py
+++ b/linter.py
@@ -92,4 +92,10 @@ class Flake8(PythonLinter):
                 count = int(match.group(1))
                 return (line - (count - 1), 0, count - 1)
 
+        if code == 'E999':
+            txt = virtual_view.select_line(line).rstrip('\n')
+            last_col = len(txt)
+            if col + 1 == last_col:
+                return line, last_col, last_col
+
         return super().reposition_match(line, col, m, virtual_view)

--- a/linter.py
+++ b/linter.py
@@ -10,7 +10,7 @@ class Flake8(PythonLinter):
     defaults = {
         'selector': 'source.python',
         # By default, filter codes Sublime can auto-fix
-        'filter-codes': ['W291', 'W293', 'W391']
+        'filter-codes': ['W291', 'W293']
     }
 
     # The following regex marks these pyflakes and pep8 codes as errors.

--- a/linter.py
+++ b/linter.py
@@ -1,7 +1,7 @@
 from SublimeLinter.lint import PythonLinter
 import re
 
-CAPTURE_WS = re.compile('(\s+)')
+CAPTURE_WS = re.compile(r'(\s+)')
 
 
 class Flake8(PythonLinter):
@@ -87,7 +87,7 @@ class Flake8(PythonLinter):
             return line - 1, 0, 1
 
         if code == 'E303':
-            match = re.match('too many blank lines \((\d+)', m.message.strip())
+            match = re.match(r'too many blank lines \((\d+)', m.message.strip())
             if match is not None:
                 count = int(match.group(1))
                 return (line - (count - 1), 0, count - 1)


### PR DESCRIPTION
Add `filter-codes` setting for post-processing the returned errors. By default,
filter some whitespace codes which Sublime will auto-fix on save.

Fixes #65 