### PR TITLE
Improve compatibility with multiple flake8 plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,6 @@ SublimeLinter-flake8 works with common flake8 [configuration files](http://flake
 
 Use ["args"](http://www.sublimelinter.com/en/latest/linter_settings.html#args) if you want to set some arguments just like on the command line.
 
+## Compatibility with flake8 Plugins
+
+SublimeLinter-flake8 is compatible with most flake8 plugins out of the box. However, some plugins, such as [flake8-aaa](https://github.com/jamescooke/flake8-aaa) and [flake8-pyi](https://github.com/ambv/flake8-pyi), select or ignore certain files based on filenames. During linting runs in SublimeLinter-flake8, these filenames are not available to flake8 and its plugins, and these plugins may appear to be "broken". A workaround for flake8 v3.0.0 and higher is to add `"--stdin-display-name ${file}"` to the ["args"](http://www.sublimelinter.com/en/latest/linter_settings.html#args) setting.

--- a/linter.py
+++ b/linter.py
@@ -13,7 +13,11 @@ CAPTURE_F403_HINT = re.compile(r"'(.*)?'")
 
 class Flake8(PythonLinter):
 
-    cmd = ('flake8', '--format', 'default', '${args}', '-')
+    cmd = (
+        'flake8',
+        '--format', 'default',
+        '--stdin-display-name', '${file}',
+        '${args}', '-')
     defaults = {
         'selector': 'source.python',
 

--- a/linter.py
+++ b/linter.py
@@ -43,7 +43,7 @@ class Flake8(PythonLinter):
     regex = (
         r'^.+?:(?P<line>\d+):(?P<col>\d+): '
         r'(?:(?P<error>(?:F(?:40[24]|8(?:12|2[123]|31))|E(?:11[23]|90[12]|999)))|'
-        r'(?P<warning>\w\d+)) '
+        r'(?P<warning>\w+\d+)) '
         r'(?P<message>.*)'
     )
     multiline = True

--- a/linter.py
+++ b/linter.py
@@ -47,7 +47,7 @@ class Flake8(PythonLinter):
     regex = (
         r'^.+?:(?P<line>\d+):(?P<col>\d+): '
         r'(?:(?P<error>(?:F(?:40[24]|8(?:12|2[123]|31))|E(?:11[23]|90[12]|999)))|'
-        r'(?P<warning>\w+\d+)) '
+        r'(?P<warning>\w+\d+):?) '
         r'(?P<message>.*)'
     )
     multiline = True


### PR DESCRIPTION
This PR adds compatibility with multiple flake8 plugins, including [flake8-aaa](https://github.com/jamescooke/flake8-aaa), [flake8-pie](https://github.com/sbdchd/flake8-pie) and possibly others (yet to discover).

Concrete changes proposed:

* Add support for multi-character warning prefixes.
As noted in the [Flake8 docs on plugins](https://flake8.readthedocs.io/en/3.7.6/plugin-development/registering-plugins.html):

> Please Note: Your entry point does not need to be exactly 4 characters as of Flake8 3.0. Consider using an entry point with 3 letters followed by 3 numbers (i.e. ABC123 ).

Meaning that as of flake8 3, it's possible to have error codes with more than one letter. There's a couple plugins that make use of this feature, e.g. [flake8-aaa](https://github.com/jamescooke/flake8-aaa) which uses `AAA01` - `AAA99`, and [flake8-pie](https://github.com/sbdchd/flake8-pie), which uses `PIE781, PIE782`.

* Pass filename into the flake8 command using `--stdin-display-name`.
Some plugins determine whether or not they need to lint a file based on its filename. Examples include `flake8-aaa`, and most likely `flake8-pyi` (although I haven't really checked). When passing in the file contents via stdin, this filename is unavailable and will cause the linter to never lint anything. Informing `flake8` about the filename using `--stdin-display-name` should allow the plugins to function properly.

* Allow optional colon after error code.
`flake8-pie` outputs its messages with a colon suffixing the error code, e.g.:
```
/path/to/my/file.py:456:5: PIE781: You are assigning to a variable and then returning. Instead remove the assignment and return.
```
The colon caused these messages to not be picked up by the linter. Perhaps this is too permissive or not permissive enough, input welcome.