### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you use pipenv, and you're working on a project with a Pipfile, everything sh
 
 Additional settings:
 
-- `ignore_fixables` (Default: `True`): Filter warnings that Sublime can fix automatically (e.g. trailing white-space) on save.
+- `ignore_fixables` (default: `True`): filter warnings that Sublime can fix automatically (e.g. trailing white-space) on save.
 
 SublimeLinter-flake8 works with common flake8 [configuration files](http://flake8.pycqa.org/en/latest/user/configuration.html#configuration-locations) and inline overrides. Note that by default the [working dir](http://www.sublimelinter.com/en/latest/linter_settings.html#working-dir) is set to an open folder attached to the current window of Sublime. Edit this setting if your config files are located in a subfolder, for example.
 


### PR DESCRIPTION
Updated README.md for flake8 3.7.0, as well as additional language review.

Notes:

* I tried to apply some general language edits to make a few sentences more natural; take or leave as you wish!
* I couldn't see anything in the [flake8 docs](http://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-stdin-display-name) for `--stdin-display-name` that indicated it was a 3.0.0 feature, so I removed the reference to the workaround only being applicable to that version and above, though if there was another code dependency that makes this necessary, it may need adding back in