### PR TITLE
Extend "E501 line too long" match till end of line

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -102,7 +102,7 @@ class Flake8(PythonLinter):
         """Reposition white-space errors."""
         code = m.error or m.warning
 
-        if code in ('W291', 'W293'):
+        if code in ('W291', 'W293', 'E501'):
             txt = virtual_view.select_line(line).rstrip('\n')
             return (line, col, len(txt))
 


### PR DESCRIPTION
Currently, positions of lints with E501 are handled by the PythonLinter base class. Since flake8 gives the column (like 80) as the hint, the base class extends the lint to the end of scope. This sometimes gives confusing results, like only outlining a single character (which would suggest that something is wrong with that char, rather than the line)

This doesn't match the semantics of E501 - everything after that column is a part of the warning/error, so the outline should extend till the end of the line.

Closes #119