### PR TITLE
Finetune position of `E303` errors

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -136,7 +136,15 @@ class Flake8(PythonLinter):
             match = re.match(r'too many blank lines \((\d+)', m.message.strip())
             if match is not None:
                 count = int(match.group(1))
-                return (line - (count - 1), 0, count - 1)
+                starting_line = line - count
+                return (
+                    starting_line,
+                    0,
+                    sum(
+                        len(virtual_view.select_line(_line))
+                        for _line in range(starting_line, line)
+                    )
+                )
 
         if code == 'E999':
             txt = virtual_view.select_line(line).rstrip('\n')


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/8558/183639219-be52f37d-11ce-464e-bd83-a74866824636.png)

After: 

![image](https://user-images.githubusercontent.com/8558/183639274-c4b9c610-95c4-4f2a-805e-8cd1190de003.png)


Especially when one of the lines had whitespace:

Before:

![image](https://user-images.githubusercontent.com/8558/183639680-c67fada9-17c1-4c16-b5c7-b09c98bfa17b.png)

Now:

![image](https://user-images.githubusercontent.com/8558/183639520-2d2b0d82-2116-4b04-9af1-43a5ee4237ce.png)
